### PR TITLE
fix off-Framework ObjectTable access

### DIFF
--- a/Dalamud.CharacterSync/CharacterSyncPlugin.cs
+++ b/Dalamud.CharacterSync/CharacterSyncPlugin.cs
@@ -64,7 +64,7 @@ namespace Dalamud.CharacterSync
                 PluginLog.Warning("Installer, safe mode...");
                 this.isSafeMode = true;
             }
-            else if (Service.ClientState.LocalPlayer != null)
+            else if (Service.ClientState.IsLoggedIn)
             {
                 PluginLog.Warning("Boot while logged in, safe mode...");
                 this.isSafeMode = true;


### PR DESCRIPTION
API 12 enforces ObjectTable accesses be on the main thread, which plugin constructors are not guaranteed to be on.